### PR TITLE
feat: align Vuedown API and security with Streamdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ import { StreamMarkdown } from 'vuedown'
 </template>
 ```
 
+### Styling
+
+Vuedown uses Tailwind utility classes. If your project already has Tailwind
+configured (Nuxt or Vite), no additional configuration is required. Make sure to
+import the KaTeX CSS once:
+
+```ts
+import 'katex/dist/katex.min.css';
+```
+
+Example Nuxt/Vite component:
+
+```vue
+<template>
+  <StreamMarkdown class="prose" :content="markdown" />
+</template>
+
+<script setup lang="ts">
+import { StreamMarkdown } from 'vuedown'
+import 'katex/dist/katex.min.css'
+const markdown = '# Hello\n\nSome *MD*';
+</script>
+```
+
 ## Development
 
 - `bun build` – build the package into `dist`

--- a/index.ts
+++ b/index.ts
@@ -2,5 +2,5 @@ export { StreamMarkdown } from './src/StreamMarkdown';
 export { default as CodeBlock } from './src/components/CodeBlock';
 export { default as MermaidBlock } from './src/components/MermaidBlock';
 export { parseMarkdownIntoBlocks } from './src/parse-blocks';
-export { fixIncompleteMarkdown } from './src/fix-incomplete-markdown';
+export { parseIncompleteMarkdown } from './src/parse-incomplete-markdown';
 export { useShikiHighlighter } from './src/use-shiki-highlighter';

--- a/src/components/CodeBlock.ts
+++ b/src/components/CodeBlock.ts
@@ -29,19 +29,27 @@ export default defineComponent({
         onBeforeUnmount(() => media.removeEventListener('change', render));
       });
       return () =>
-        h('div', { class: 'relative group' }, [
-          h('div', { innerHTML: html.value }),
-          props.language
-            ? h(
-                'span',
-                {
-                  class:
-                    'absolute top-2 left-2 text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 opacity-0 group-hover:opacity-100',
-                },
-                props.language
-              )
-            : null,
-          h(CopyButton, { text: props.code }),
-        ]);
+        h(
+          'div',
+          {
+            class:
+              'relative group rounded-md border bg-gray-50 dark:bg-gray-800 p-4',
+            'data-streamdown': 'code-block',
+          },
+          [
+            h('div', { innerHTML: html.value }),
+            props.language
+              ? h(
+                  'span',
+                  {
+                    class:
+                      'absolute top-2 left-2 text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 opacity-0 group-hover:opacity-100',
+                  },
+                  props.language
+                )
+              : null,
+            h(CopyButton, { text: props.code }),
+          ]
+        );
     },
 });

--- a/src/components/MermaidBlock.ts
+++ b/src/components/MermaidBlock.ts
@@ -1,40 +1,62 @@
 import { defineComponent, h, onMounted, ref } from 'vue';
 import CopyButton from './CopyButton';
 
+let initialized = false;
+const cache: Record<string, string> = {};
+const hash = (str: string): string => {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (h << 5) - h + str.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h).toString(36);
+};
+
 export default defineComponent({
   name: 'MermaidBlock',
   props: {
     code: { type: String, required: true },
   },
-    setup(props) {
-      const svg = ref('');
-      const lastGood = ref('');
-      const error = ref('');
-      const loading = ref(true);
+  setup(props) {
+    const svg = ref('');
+    const lastGood = ref('');
+    const error = ref('');
+    const loading = ref(true);
+    const id = `vuedown-mermaid-${hash(props.code)}`;
 
-      const render = async () => {
-        loading.value = true;
-        try {
-          const mermaid = (await import('mermaid')).default;
-          const { svg: out } = await mermaid.render(
-            `vuedown-mermaid-${Math.random().toString(36).slice(2)}`,
-            props.code
-          );
-          svg.value = out;
-          lastGood.value = out;
-          error.value = '';
-        } catch (e: any) {
-          error.value = e.message || 'Failed to render mermaid diagram';
-          svg.value = lastGood.value;
-        } finally {
-          loading.value = false;
+    const render = async () => {
+      loading.value = true;
+      try {
+        const mermaid = (await import('mermaid')).default;
+        if (!initialized) {
+          mermaid.initialize({ startOnLoad: false });
+          initialized = true;
         }
-      };
+        if (cache[id]) {
+          svg.value = cache[id];
+          loading.value = false;
+          return;
+        }
+        const { svg: out } = await mermaid.render(id, props.code);
+        svg.value = out;
+        lastGood.value = out;
+        cache[id] = out;
+        error.value = '';
+      } catch (e: any) {
+        error.value = e.message || 'Failed to render mermaid diagram';
+        svg.value = lastGood.value;
+      } finally {
+        loading.value = false;
+      }
+    };
 
-      onMounted(render);
+    onMounted(render);
 
-      return () =>
-        h('div', { class: 'relative group' }, [
+    return () =>
+      h(
+        'div',
+        { class: 'relative group', 'data-streamdown': 'mermaid' },
+        [
           loading.value
             ? h('div', { class: 'flex justify-center py-8' }, [
                 h('div', {
@@ -49,6 +71,7 @@ export default defineComponent({
             ? h('div', { class: 'text-red-500 text-sm mt-2' }, error.value)
             : null,
           h(CopyButton, { text: props.code }),
-        ]);
-    },
-  });
+        ]
+      );
+  },
+});

--- a/src/components/components.ts
+++ b/src/components/components.ts
@@ -1,0 +1,65 @@
+import { h } from 'vue';
+
+export type ComponentMap = Record<string, any>;
+
+const mergeClass = (existing?: any, extra?: string) => {
+  const cls: string[] = [];
+  if (Array.isArray(existing)) cls.push(...existing);
+  else if (typeof existing === 'string') cls.push(existing);
+  if (extra) cls.push(extra);
+  return cls.join(' ').trim();
+};
+
+const wrap = (tag: string, baseClass = '', dataAttr?: string) => {
+  return (props: any, { slots }: any) => {
+    const className = mergeClass(props.class || props.className, baseClass);
+    const attrs = { ...props, class: className || undefined } as any;
+    if (dataAttr) attrs['data-streamdown'] = dataAttr;
+    delete attrs.className;
+    return h(tag, attrs, slots.default ? slots.default() : []);
+  };
+};
+
+export const defaultComponents: ComponentMap = {
+  p: wrap('p', 'mb-2', 'p'),
+  a: (props: any, { slots }: any) => {
+    const className = mergeClass(props.class || props.className, 'underline text-blue-600');
+    const attrs: any = { ...props, class: className || undefined, 'data-streamdown': 'a', target: '_blank', rel: 'noreferrer' };
+    delete attrs.className;
+    return h('a', attrs, slots.default ? slots.default() : []);
+  },
+  code: wrap('code', 'bg-muted px-1.5 py-0.5 font-mono text-sm', 'inline-code'),
+  ul: wrap('ul', 'list-disc pl-6', 'ul'),
+  ol: wrap('ol', 'list-decimal pl-6', 'ol'),
+  li: wrap('li', '', 'li'),
+  hr: wrap('hr', 'my-6 border-border', 'hr'),
+  strong: wrap('strong', '', 'strong'),
+  em: wrap('em', '', 'em'),
+  h1: wrap('h1', 'text-3xl font-bold', 'h1'),
+  h2: wrap('h2', 'text-2xl font-bold', 'h2'),
+  h3: wrap('h3', 'text-xl font-semibold', 'h3'),
+  h4: wrap('h4', 'text-lg font-semibold', 'h4'),
+  h5: wrap('h5', 'font-semibold', 'h5'),
+  h6: wrap('h6', 'font-semibold', 'h6'),
+  blockquote: wrap('blockquote', 'border-l-4 pl-4 italic', 'blockquote'),
+  table: (props: any, { slots }: any) => {
+    const className = mergeClass(props.class || props.className, 'w-full text-sm');
+    const attrs: any = { ...props, class: className || undefined, 'data-streamdown': 'table' };
+    delete attrs.className;
+    const table = h('table', attrs, slots.default ? slots.default() : []);
+    return h('div', { class: 'overflow-x-auto', 'data-streamdown': 'table-wrapper' }, [table]);
+  },
+  thead: wrap('thead', '', 'thead'),
+  tbody: wrap('tbody', '', 'tbody'),
+  tr: wrap('tr', '', 'tr'),
+  th: wrap('th', 'border px-2 py-1', 'th'),
+  td: wrap('td', 'border px-2 py-1', 'td'),
+  img: (props: any) => {
+    const className = mergeClass(props.class || props.className, '');
+    const attrs: any = { ...props, class: className || undefined, 'data-streamdown': 'img' };
+    delete attrs.className;
+    return h('img', attrs);
+  },
+};
+
+export default defaultComponents;

--- a/src/parse-incomplete-markdown.ts
+++ b/src/parse-incomplete-markdown.ts
@@ -361,7 +361,7 @@ const handleIncompleteBoldItalic = (text: string): string => {
 };
 
 // Auto-closes unbalanced markdown tokens so streaming content always renders
-export const fixIncompleteMarkdown = (text: string): string => {
+export const parseIncompleteMarkdown = (text: string): string => {
   if (!text || typeof text !== 'string') {
     return text;
   }

--- a/src/security/harden-vue-markdown.ts
+++ b/src/security/harden-vue-markdown.ts
@@ -1,0 +1,36 @@
+export interface HardenOptions {
+  defaultOrigin?: string;
+  allowedLinkPrefixes: string[];
+  allowedImagePrefixes: string[];
+}
+
+const resolveUrl = (url: string, base?: string): string => {
+  if (!base) return url;
+  try {
+    return new URL(url, base).toString();
+  } catch {
+    return url;
+  }
+};
+
+export const sanitizeUrl = (
+  url: string,
+  prefixes: string[],
+  defaultOrigin?: string
+): string | null => {
+  if (!url) return null;
+  let resolved = url.trim();
+  resolved = resolveUrl(resolved, defaultOrigin);
+  const lower = resolved.toLowerCase();
+  if (lower.startsWith('javascript:')) return null;
+  if (!prefixes.some((p) => lower.startsWith(p))) return null;
+  return resolved;
+};
+
+export const hardenHref = (href: string, opts: HardenOptions): string | null => {
+  return sanitizeUrl(href, opts.allowedLinkPrefixes, opts.defaultOrigin);
+};
+
+export const hardenSrc = (src: string, opts: HardenOptions): string | null => {
+  return sanitizeUrl(src, opts.allowedImagePrefixes, opts.defaultOrigin);
+};

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import { parseMarkdownIntoBlocks } from '../src/parse-blocks';
-import { fixIncompleteMarkdown } from '../src/fix-incomplete-markdown';
+import { parseIncompleteMarkdown } from '../src/parse-incomplete-markdown';
 
 test('parseMarkdownIntoBlocks splits markdown into blocks', () => {
   const md = '# Title\n\nParagraph one.\n\n- item1\n- item2';
@@ -8,7 +8,12 @@ test('parseMarkdownIntoBlocks splits markdown into blocks', () => {
   expect(blocks.length).toBeGreaterThan(1);
 });
 
-test('fixIncompleteMarkdown closes unclosed bold', () => {
+test('parseIncompleteMarkdown closes unclosed bold', () => {
   const md = '**bold';
-  expect(fixIncompleteMarkdown(md)).toBe('**bold**');
+  expect(parseIncompleteMarkdown(md)).toBe('**bold**');
+});
+
+test('single dollar sign is left alone', () => {
+  const md = 'Cost is $5';
+  expect(parseIncompleteMarkdown(md)).toBe('Cost is $5');
 });

--- a/tests/stream-markdown.test.ts
+++ b/tests/stream-markdown.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'bun:test';
 import { createSSRApp } from 'vue';
 import { renderToString } from '@vue/server-renderer';
 import { StreamMarkdown } from '../src/StreamMarkdown';
+import type { Plugin } from 'unified';
+import { defineComponent, h } from 'vue';
 
 test('renders basic markdown', async () => {
   const app = createSSRApp(StreamMarkdown, { content: '# Hello' });
@@ -13,4 +15,88 @@ test('filters disallowed links', async () => {
   const app = createSSRApp(StreamMarkdown, { content: '[x](javascript:alert(1))' });
   const html = await renderToString(app);
   expect(html).not.toContain('<a');
+});
+
+test('filters disallowed images', async () => {
+  const app = createSSRApp(StreamMarkdown, { content: '![x](javascript:evil)' });
+  const html = await renderToString(app);
+  expect(html).not.toContain('<img');
+});
+
+test('enforces allowed image prefixes', async () => {
+  const app = createSSRApp(StreamMarkdown, {
+    content: '![x](http://example.com/a.png)',
+    allowedImagePrefixes: ['https://'],
+  });
+  const html = await renderToString(app);
+  expect(html).not.toContain('<img');
+});
+
+test('slot content takes precedence over prop', async () => {
+  const app = createSSRApp({
+    render() {
+      return h(
+        StreamMarkdown,
+        { content: '# Prop' },
+        { default: () => '# Slot' }
+      );
+    },
+  });
+  const html = await renderToString(app);
+  expect(html).toContain('<h1');
+  expect(html).not.toContain('Prop');
+});
+
+test('allows relative links with defaultOrigin', async () => {
+  const app = createSSRApp(StreamMarkdown, {
+    content: '[ok](/test)',
+    defaultOrigin: 'https://example.com',
+    allowedLinkPrefixes: ['https://'],
+  });
+  const html = await renderToString(app);
+  expect(html).toContain('href="https://example.com/test"');
+});
+
+test('inline and block code have data attributes', async () => {
+  const md = '`inline`\n\n```js\ncode\n```';
+  const app = createSSRApp(StreamMarkdown, { content: md });
+  const html = await renderToString(app);
+  expect(html).toContain('data-streamdown="inline-code"');
+  expect(html).toContain('data-streamdown="code-block"');
+  expect(html).toContain('button'); // copy button
+});
+
+test('custom components override defaults', async () => {
+  const P = defineComponent({
+    setup(_, { slots }) {
+      return () => h('p', { class: 'text-red-500' }, slots.default?.());
+    },
+  });
+  const app = createSSRApp(StreamMarkdown, {
+    content: 'hi',
+    components: { p: P },
+  });
+  const html = await renderToString(app);
+  expect(html).toContain('text-red-500');
+});
+
+test('remark and rehype plugins are applied', async () => {
+  const remark: Plugin = () => (tree: any) => {
+    tree.children.push({ type: 'paragraph', children: [{ type: 'text', value: 'tail' }] });
+  };
+  const rehype: Plugin = () => (tree: any) => {
+    const first = tree.children[0];
+    if (first && first.type === 'element') {
+      first.properties = first.properties || {};
+      first.properties['data-test'] = 'ok';
+    }
+  };
+  const app = createSSRApp(StreamMarkdown, {
+    content: '# head',
+    remarkPlugins: [remark],
+    rehypePlugins: [rehype],
+  });
+  const html = await renderToString(app);
+  expect(html).toContain('data-test="ok"');
+  expect(html).toContain('tail');
 });


### PR DESCRIPTION
## Summary
- rename `parseIncompleteMarkdown` prop and expose additional Streamdown-compatible options
- add centralized Vue component map with Tailwind classes and `data-streamdown` attributes
- harden link and image rendering via allowed prefixes and default origin
- enhance code and mermaid blocks with copy buttons and caching
- document Tailwind styling setup

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b7458ce6a48327918e7a4a75f16c45