### PR TITLE
docs: expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,118 @@
 # vuedown
 
-Vuedown provides a `<StreamMarkdown>` component that mirrors the feature set of
-[Streamdown](https://github.com/vercel/streamdown) for Vue/Nuxt apps. It splits
-incoming Markdown into blocks, repairs incomplete syntax during streaming, and
-renders each block incrementally.
+Vuedown brings [Streamdown](https://github.com/vercel/streamdown)-style streaming Markdown to Vue 3 and Nuxt 3. It ships a `<StreamMarkdown>` component that incrementally renders Markdown as it arrives, keeping UIs snappy even when content is streamed token by token.
 
-### Features
+## Features
 
-- GitHub‑flavored Markdown (tables, task lists, strikethrough)
-- KaTeX math rendering
-- Advanced LaTeX fixes for matrices and dollar-sign math
-- Syntax‑highlighted code blocks with copy button and light/dark themes (Shiki)
-- Mermaid diagrams with loading spinner, error recovery and copy button
-- Auto‑fixes incomplete Markdown tokens while streaming
-- Link and image prefix allow‑list for security
-- Tailwind‑friendly styling (`space-y-4`, responsive tables, inline code styling, etc.)
+- GitHub‑flavored Markdown support (tables, task lists, strikethrough)
+- KaTeX math with extra LaTeX fixes for matrices and dollar-sign math
+- Shiki‑powered syntax highlighting with copy button and light/dark themes
+- Mermaid diagrams with loading spinner, copy button and error recovery
+- Automatically repairs incomplete Markdown tokens while streaming
+- Configurable security allow‑lists for links and images
+- Tailwind‑friendly styling (`space-y-4`, responsive tables, inline code styling)
 
-## Usage
+## Installation
+
+### Bun
+
+```bash
+bun add vuedown
+```
+
+### npm / pnpm / yarn
+
+```bash
+npm install vuedown
+```
+
+## Quick start
 
 ```ts
-import { StreamMarkdown, parseBlocks, parseIncompleteMarkdown } from 'vuedown'
+// main.ts
+import { createApp } from 'vue'
+import App from './App.vue'
+import 'katex/dist/katex.min.css'
+createApp(App).mount('#app')
 ```
 
 ```vue
-<template>
-  <StreamMarkdown :content="markdown" />
-</template>
-```
-
-### Styling
-
-Vuedown uses Tailwind utility classes. If your project already has Tailwind
-configured (Nuxt or Vite), no additional configuration is required. Make sure to
-import the KaTeX CSS once:
-
-```ts
-import 'katex/dist/katex.min.css';
-```
-
-Example Nuxt/Vite component:
-
-```vue
+<!-- App.vue -->
 <template>
   <StreamMarkdown class="prose" :content="markdown" />
 </template>
 
 <script setup lang="ts">
 import { StreamMarkdown } from 'vuedown'
-import 'katex/dist/katex.min.css'
-const markdown = '# Hello\n\nSome *MD*';
+const markdown = '# Hello\n\nSome *MD*'
 </script>
 ```
 
+## Streaming example
+
+The utilities `parseBlocks` and `parseIncompleteMarkdown` help you render while content is still arriving from a `ReadableStream` (e.g. an AI or SSE endpoint).
+
+```ts
+import { StreamMarkdown, parseBlocks, parseIncompleteMarkdown } from 'vuedown'
+
+const res = await fetch('/api/stream')
+const reader = res.body!.getReader()
+let buffer = ''
+let blocks: string[] = []
+
+while (true) {
+  const { value, done } = await reader.read()
+  if (done) break
+  buffer += new TextDecoder().decode(value)
+  buffer = parseIncompleteMarkdown(buffer)
+  blocks = parseBlocks(buffer)
+  // use blocks.join('') as the content for <StreamMarkdown>
+}
+```
+
+## Customisation
+
+### Override built‑in components
+
+```vue
+<StreamMarkdown :components="{ code: MyCodeBlock }" />
+```
+
+### Add remark/rehype plugins
+
+```vue
+<StreamMarkdown :remark-plugins="[myRemark]" :rehype-plugins="[myRehype]" />
+```
+
+### Security options
+
+```vue
+<StreamMarkdown
+  :allowed-link-prefixes="['https://']"
+  :allowed-image-prefixes="['https://cdn.example.com']"
+  default-origin="https://example.com"
+/>
+```
+
+## Styling
+
+Vuedown ships with minimal Tailwind classes. Add your own classes (e.g. `prose`) and include the KaTeX stylesheet once if you use math:
+
+```ts
+import 'katex/dist/katex.min.css'
+```
+
+## Utilities
+
+- `parseBlocks(text)` – split Markdown into renderable chunks for streaming.
+- `parseIncompleteMarkdown(text)` – close open Markdown tokens so partial text still renders.
+
+Both utilities are exported from the package and can be used outside the component.
+
 ## Development
 
-- `bun build` – build the package into `dist`
-- `bun test` – run unit tests
+```bash
+bun build   # build the package into dist/
+bun test    # run unit tests
+```
+


### PR DESCRIPTION
## Summary
- expand README with installation, streaming, and customization guides
- document utilities and development commands

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b75dd31198832787c2dd435c91e5f6